### PR TITLE
Add extension that prevents empty inputs from being submitted in poster form

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -175,8 +175,13 @@ function openSavedPosters() {
 
 function createMyPoster() {
   event.preventDefault();
-  currentPoster = new Poster(imageInput.value, titleInput.value, quoteInput.value);
+  if (imageInput.value == '' || titleInput.value == '' || quoteInput.value == '') {
+    alert('Missing an input ya dummy!');
+   return
+  }
 
+  currentPoster = new Poster(imageInput.value, titleInput.value, quoteInput.value);
+  
   images.push(imageInput.value);
   titles.push(titleInput.value);
   quotes.push(quoteInput.value);
@@ -208,3 +213,5 @@ function deletePoster(event) {
   }
   openSavedPosters();
 }
+
+


### PR DESCRIPTION

### What does this PR do?  
Adds an extension to poster form function

### What is the change?  
If an input is left blank, an alert will pop up prompting the user to fill the blank

### What does it fix?  
Possible incomplete posters from being made.

### Is this a feature or a fix?  
This is both in a way. The feature is that an alert will pop up and inform the user of error. The fix is that the button will no longer allow for an incomplete poster to be made.

### Where should the reviewer start?  
At function createMyPoster

### How should this be tested?
Leaving poster form input fields blank and clicking the make my poster button.